### PR TITLE
Added support for multiple input FEDs in HLTL1NumberFilter 

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -147,7 +147,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_15_0_14"
+    'default': "CMSSW_15_0_15"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
Added support for multiple input TCDS  FEDs in HLTL1NumberFilter.  These changes are  available in CMSSW from CMSSW_15_0_15 


# Replay Request


**Requestor**  

ORM
(@prpalni)

**Describe the configuration**  
* Release: CMSSW_15_0_15 
* Run: 
* GTs:
   * expressGlobalTag: 
   * promptrecoGlobalTag:
* Additional changes:

**Purpose of the test**  

A test is necessary to validate the added support for multiple input TCDS FEDs in HLTL1NumberFilter runs smoothly

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
